### PR TITLE
Test : fixed display problem

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../components/my_drawer.dart'
+import '../components/my_drawer.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../components/my_drawer.dart'
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -9,7 +10,7 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text("Home"),
       ),
-      drawer: Drawer(),
+      drawer: MyDrawer(),
     );
   }
 }


### PR DESCRIPTION
Le problème ici est que j'ai ajouté un Drawer générique sans contenu, au lieu d'utiliser le widget personnalisé MyDrawer que j'ai défini dans my_drawer.dart. Pour afficher le tiroir personnalisé, il faut remplacer drawer: Drawer(), par drawer: MyDrawer(), dans le fichier home_page.dart.